### PR TITLE
clarat-org/clarat#1421 - removed delegate to split_base (code_word still exists in DB)

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -63,8 +63,6 @@ class Offer < ApplicationRecord
   delegate :minlat, :maxlat, :minlong, :maxlong,
            to: :area, prefix: true, allow_nil: true
 
-  delegate :code_word, to: :split_base, prefix: false
-
   def organization_count
     organizations.count
   end


### PR DESCRIPTION
-> clarat-org/clarat#1421